### PR TITLE
devops.pf -> tahiti.dev

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-map.devops.pf
+map.tahiti.dev

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# map.devops.pf
+# map.tahiti.dev
 
 Pour rajouter votre contact (vous n'y êtes pas obligé·e bien sûr), vous devez :
 
@@ -30,8 +30,8 @@ Prérequis :
 Note: Vous pouvez utiliser [rbenv](https://github.com/rbenv/rbenv) ou [RVM](https://rvm.io/rvm/install) si vous n'avez pas déjà un environnement Ruby fonctionnel ou si vous n'êtes pas administrateur·rice de votre machine.
 
 ```
-$ git clone https://github.com/tahitidevops/map.devops.pf.git
-$ cd map.devops.pf
+$ git clone https://github.com/tahitidevops/map.tahiti.dev.git
+$ cd map.tahiti.dev
 $ bundle install
 $ bundle exec jekyll serve
 ```

--- a/about.md
+++ b/about.md
@@ -4,7 +4,7 @@ layout: page
 
 # Carte des membres de Tahiti DevOps
 
-Ce site présente [une carte](/) des membres de [Tahiti DevOps](https://devops.pf/) qui souhaitent y figurer.
+Ce site présente [une carte](/) des membres de [Tahiti DevOps](https://tahiti.dev/) qui souhaitent y figurer.
 
 Pour ajouter / modifier / supprimer votre fiche, envoyez une Pull-Request sur le dépôt du projet:
 


### PR DESCRIPTION
The old domain is gone:

```sh-session
romain@desktop-fln40kq ~ % whois devops.pf
This is the PF top level domain whois server.
Informations about 'devops.pf' :

Domain unknown
```
